### PR TITLE
removes bad default WaitStrategy in demo snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The current logstash-logback-encoder.version is 4.7.
     <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
     <appender name="REDIS_APPENDER" class="net.logstash.logback.appender.LoggingEventAsyncDisruptorAppender">
         <ringBufferSize>131072</ringBufferSize>
-        <waitStrategyType>sleeping</waitStrategyType>
         <appender class="de.idealo.logback.appender.RedisBatchAppender">
             <connectionConfig>
                 <!-- redis sentinel: -->


### PR DESCRIPTION
- http://grokbase.com/t/gg/graylog2/12bw0tv8vq/disruptor-and-cpu-usage
- https://github.com/logstash/logstash-logback-encoder/issues/75
