### PR TITLE
Upgrade to Jedis 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.9.0</version>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/de/idealo/logback/appender/jedisclient/JedisClientProvider.java
+++ b/src/main/java/de/idealo/logback/appender/jedisclient/JedisClientProvider.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.Jedis;
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Pool;
 
 public class JedisClientProvider implements Closeable {
 

--- a/src/main/java/de/idealo/logback/appender/jedisclient/JedisPoolFactory.java
+++ b/src/main/java/de/idealo/logback/appender/jedisclient/JedisPoolFactory.java
@@ -3,7 +3,7 @@ package de.idealo.logback.appender.jedisclient;
 import java.util.Arrays;
 
 import redis.clients.jedis.Jedis;
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Pool;
 
 /**
  * Factory for Jedis pool creation. Supports the creation of clients for single and sentinel Redis installations.

--- a/src/test/java/de/idealo/logback/appender/jedisclient/JedisClientProviderTest.java
+++ b/src/test/java/de/idealo/logback/appender/jedisclient/JedisClientProviderTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import redis.clients.jedis.Jedis;
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Pool;
 
 public class JedisClientProviderTest {
     @Mock

--- a/src/test/java/de/idealo/logback/appender/jedisclient/JedisPoolFactoryTest.java
+++ b/src/test/java/de/idealo/logback/appender/jedisclient/JedisPoolFactoryTest.java
@@ -15,7 +15,7 @@ import org.mockito.MockitoAnnotations;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisSentinelPool;
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Pool;
 
 public class JedisPoolFactoryTest {
 


### PR DESCRIPTION
In order to be compatible with Spring Boot 2.2.0 and above I had to upgrade to Jedis 3.x.